### PR TITLE
Update Homebrew formula to v0.2.0

### DIFF
--- a/Formula/confirm-pam.rb
+++ b/Formula/confirm-pam.rb
@@ -1,8 +1,8 @@
 class ConfirmPam < Formula
   desc "A CLI tool for biometric authentication confirmation"
   homepage "https://github.com/azu/confirm-pam"
-  url "https://github.com/azu/confirm-pam/releases/download/v0.1.0/confirm-pam-macos-amd64.tar.gz"
-  sha256 "636c9cb66c3c5244ad318e4cf9516f04713fd1ee946cac2cc8ed16bf4775c32f"
+  url "https://github.com/azu/confirm-pam/releases/download/v0.2.0/confirm-pam-macos-amd64.tar.gz"
+  sha256 "ab426d487246d10f4d3253b7adbcf579574a2edd39308d5b94ec19fc47da70de"
   license "MIT"
 
   def install


### PR DESCRIPTION
Updates the Homebrew formula for release v0.2.0

- URL: https://github.com/azu/confirm-pam/releases/download/v0.2.0/confirm-pam-macos-amd64.tar.gz  
- SHA256: ab426d487246d10f4d3253b7adbcf579574a2edd39308d5b94ec19fc47da70de

This PR was created to update the Homebrew formula after the automated workflow created the branch.